### PR TITLE
Add configuration option to use default:dirt as soil

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -1,3 +1,11 @@
+local SOIL = "moonrealm:soil" -- Used to grow moonrealm:appletree and to be saturated by moonrealm:hlsource
+local DRYSOIL = {"moonrealm:soil"} -- This is dried into moonrealm:dust when there is no moonrealm:hlsource nearby
+
+if SOIL_IS_DIRT then
+	SOIL = "default:dirt"
+	DRYSOIL = { "group:soil" }
+end
+
 -- Space apple tree
 
 function moonrealm_appletree(pos)
@@ -8,7 +16,7 @@ function moonrealm_appletree(pos)
 	local c_tree = minetest.get_content_id("default:tree")
 	local c_apple = minetest.get_content_id("default:apple")
 	local c_appleleaf = minetest.get_content_id("moonrealm:appleleaf")
-	local c_soil = minetest.get_content_id("moonrealm:soil")
+	local c_soil = minetest.get_content_id(SOIL)
 	local c_lsair = minetest.get_content_id("moonrealm:air")
 
 	local vm = minetest.get_voxel_manip()
@@ -190,8 +198,7 @@ minetest.register_abm({
 		local c_dust = minetest.get_content_id("moonrealm:dust")
 		local c_dustp1 = minetest.get_content_id("moonrealm:dustprint1")
 		local c_dustp2 = minetest.get_content_id("moonrealm:dustprint2")
-		local c_soil = minetest.get_content_id("moonrealm:soil")
-	
+		local c_soil = minetest.get_content_id(SOIL)
 		local vm = minetest.get_voxel_manip()
 		local pos1 = {x=x-2, y=y-4, z=z-2}
 		local pos2 = {x=x+2, y=y, z=z+2}
@@ -227,7 +234,7 @@ minetest.register_abm({
 -- Soil drying ABM
 
 minetest.register_abm({
-	nodenames = {"moonrealm:soil"},
+	nodenames = DRYSOIL,
 	interval = 31,
 	chance = 9,
 	action = function(pos, node)

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,20 @@
 -- Parameters
 
+-- These are given to a player who spawns in a shell
+-- To give each player items in their inventory, try the 'give_initial_stuff' mod
+local GIVE_INITIAL_STUFF = { "moonrealm:spacesuit 4", "moonrealm:sapling 4",
+				"moonrealm:airlock 4", "moonrealm:airgen 4",
+				"moonrealm:hlsource 4", "default:apple 64",
+				"default:pick_diamond 4", "default:axe_diamond 4",
+				"default:shovel_diamond 4"
+			}
+-- Set to true to make moonrealm:soil actually default:dirt. This means default:dirt
+-- will dry into moonrealm:dust if no moonrealm:hlsource is nearby
+      SOIL_IS_DIRT = false
+-- Allow each player to spawn in their own shell. If false, normal spawn applies.
+-- Try setting to false for public servers
+local SPAWN_WITH_SHELL = true
+
 local YMIN = -8000 -- Approx lower limit
 local GRADCEN = 1 -- Gradient centre / terrain centre average level
 local YMAX = 8000 -- Approx upper limit
@@ -484,6 +499,11 @@ function moonrealm_spawnplayer(player)
 	print ("[moonrealm] spawn player ("..xsp.." "..ysp.." "..zsp..")")
 	player:setpos({x = xsp, y = ysp, z = zsp})
 
+	for i,v in ipairs(GIVE_INITIAL_STUFF) do
+		minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, v)
+        end
+
+--[[
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "moonrealm:spacesuit 4")
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "moonrealm:sapling 4")
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "moonrealm:airlock 4")
@@ -493,7 +513,7 @@ function moonrealm_spawnplayer(player)
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "default:pick_diamond 4")
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "default:axe_diamond 4")
 	minetest.add_item({x = xsp, y = ysp + 1, z = zsp}, "default:shovel_diamond 4")
-
+]]
 	local vm = minetest.get_voxel_manip()
 	local pos1 = {x = xsp - 3, y = ysp - 3, z = zsp - 3}
 	local pos2 = {x = xsp + 3, y = ysp + 6, z = zsp + 3}
@@ -533,11 +553,15 @@ end
 
 
 minetest.register_on_newplayer(function(player)
-	moonrealm_spawnplayer(player)
+	if SPAWN_WITH_SHELL then
+		moonrealm_spawnplayer(player)
+	end
 end)
 
 minetest.register_on_respawnplayer(function(player)
-	moonrealm_spawnplayer(player)
+	if SPAWN_WITH_SHELL then
+		moonrealm_spawnplayer(player)
+	end
 	return true
 end)
 

--- a/nodes.lua
+++ b/nodes.lua
@@ -201,14 +201,16 @@ minetest.register_node("moonrealm:hlsource", {
 	groups = {water=3, liquid=3, puts_out_fire=1},
 })
 
-minetest.register_node("moonrealm:soil", {
-	description = "Moonsoil",
-	tiles = {"moonrealm_soil.png"},
-	is_ground_content = false,
-	groups = {crumbly=3},
-	drop = "moonrealm:dust",
-	sounds = default.node_sound_dirt_defaults(),
-})
+if SOIL_IS_DIRT ~= true then 
+	minetest.register_node("moonrealm:soil", {
+		description = "Moonsoil",
+		tiles = {"moonrealm_soil.png"},
+		is_ground_content = false,
+		groups = {crumbly=3},
+		drop = "moonrealm:dust",
+		sounds = default.node_sound_dirt_defaults(),
+	})
+end
 
 minetest.register_node("moonrealm:airlock", {
 	description = "Airlock",


### PR DESCRIPTION
This allows the functions that create and use moonrealm:soil to instead create and use default:dirt. This allows players to work with materials they are familiar with, it allows farming mods to integrate directly to this mod, and it allows a server to use all of those dirt nodes that otherwise are wasted space.

In addition, this includes a configuration option to prevent the egg-spawning events to occur, which allows the mod to function as expected on a public server. Related to that, the list of objects given when egg-spawning is now an array in the heading of the init file, which allows the items to be changed without diving into the code.
